### PR TITLE
NPE running via maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ produced by this project.
 Quick Start
 -----------
 
-    $ mvn clean install exec:exec
+    $ mvn clean install exec:java
 
 Open your web browser to
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,14 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2</version>
+        
         <configuration>
+          <mainClass>org.eclipse.jetty.demo.EmbedMe</mainClass>
           <classpathScope>test</classpathScope>
-          <executable>java</executable>
+          <additionalClasspathElements>
+            <additionalClasspathElement>${project.build.directory}/${pom.name}-${project.version}</additionalClasspathElement>
+          </additionalClasspathElements>          
           <arguments>
-            <argument>-cp</argument>
-            <classpath />
-            <argument>org.eclipse.jetty.demo.EmbedMe</argument>
             <argument>8080</argument>
           </arguments>
         </configuration>


### PR DESCRIPTION
Sorry, in my previous pull request #1 I did not test running the project via maven. It is currently failing with a NPE as the web.xml is _not_ on the classpath. I blame the difficulty here on the mismatch of a Maven war artifact vs. the use case of a embedded web server (which I feel begs for a JAR artifact, but then the war would not be deployable on a regular web container).

This new PR fixes that by adding the target/embedded-servlet-3.1-1-SNAPSHOT/ directory  to the classpath. It also uses exec:java instead of exec:exec (which I tend to use only when exec'ing non Java code).
